### PR TITLE
add twentytwenty back to list

### DIFF
--- a/README_CLEANED.md
+++ b/README_CLEANED.md
@@ -577,6 +577,7 @@ Tooltips / popovers
  - [vue-touch-ripple](https://github.com/surmon-china/vue-touch-ripple) - Touch ripple component for Vue.js(1.x ~ 2.x).
  - [vue-typer](https://github.com/cngu/vue-typer) - Vue component that simulates a user typing, selecting, and erasing text.
  - [vue-keyboard](https://github.com/MartyWallace/vue-keyboard) - Vue 2 virtual keyboard component.
+ - [vue-twentytwenty](https://github.com/mhayes/vue-twentytwenty) - Image comparison component, works with Vue.js 2.x
 
 
 


### PR DESCRIPTION
Adds `vue-twentytwenty` back to list. The following improvements have been made:

  * Removed dependency on sass
  * UMD build now included
  * Updated documentation
  * Added live demo

Thank you for all the hard work @brillout, cleaning things up is no fun task but is very important. Let me know if there's any other improvements that you'd like to see, cheers.